### PR TITLE
Update postgis dep to deal with HMAC crate version being yanked.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "diesel-geography"
-version = "0.2.0"
-authors = ["Boscop"]
+version = "0.2.2"
+authors = ["Boscop", "Keorn"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Boscop/diesel-geography"
@@ -12,5 +12,5 @@ categories = ["database"]
 
 [dependencies]
 diesel = { version = "1.3", features = ["postgres"] }
-postgis = "0.6"
+postgis = "0.8"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Current version depends on `postgis` 0.6 which has a dependency tree that pulls in a yanked HMAC crate version.

I checked the current version of Postgis, and the `Point` struct has remained the same. So I've updated to it to 0.8 in order to fix dependency errors.